### PR TITLE
Fix PDF image rendering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -281,6 +281,9 @@ initializeReset();
 $(document).ready(function() {
   // Only show the loader initially
   $('#loader').show();
+  setTimeout(() => {
+    $('#loader').fadeOut();
+  }, 5000);
   
   // Rest of your document.ready code...
 });

--- a/src/pdfGenerator.js
+++ b/src/pdfGenerator.js
@@ -72,9 +72,10 @@ function renderSkuAndDate(doc) {
 
 function renderSelectedImage(doc) {
   // Selected Image
-  const photo = $('#selected-image').attr('src');
-  const encodedPhotoURL = encodeURIComponent(photo);
-  doc.addImage(encodedPhotoURL, 'JPEG', 46, 12, 65, 65);
+  const imgEl = document.getElementById('selected-image');
+  if (imgEl) {
+    doc.addImage(imgEl, 'JPEG', 46, 12, 65, 65);
+  }
 }
 
 function renderStyleDetails(doc, selectedOptions) {

--- a/src/pdfHelper.js
+++ b/src/pdfHelper.js
@@ -166,9 +166,10 @@ const PDFHelper = {
       },
       renderSelectedImage(doc) {
         // Selected Image
-        const photo = $('#selected-image').attr('src');
-        const encodedPhotoURL = encodeURIComponent(photo);
-        doc.addImage(encodedPhotoURL, 'JPEG', 46, 12, 65, 65);
+        const imgEl = document.getElementById('selected-image');
+        if (imgEl) {
+          doc.addImage(imgEl, 'JPEG', 46, 12, 65, 65);
+        }
       },
       renderSizeDetails(doc, selectedOptions) {
         let sizeDetailsLabel = '';

--- a/src/polishedPdfGenerator.js
+++ b/src/polishedPdfGenerator.js
@@ -70,9 +70,10 @@ function renderSkuAndDate(doc) {
 }
 
 function renderSelectedImage(doc) {
-  const photo = $('#selected-image').attr('src');
-  const encodedPhotoURL = encodeURIComponent(photo);
-  doc.addImage(encodedPhotoURL, 'JPEG', 46, 12, 65, 65);
+  const imgEl = document.getElementById('selected-image');
+  if (imgEl) {
+    doc.addImage(imgEl, 'JPEG', 46, 12, 65, 65);
+  }
 }
 
 function renderItemCode(doc, selectedOptions) {

--- a/src/suspendedPdfGenerator.js
+++ b/src/suspendedPdfGenerator.js
@@ -132,9 +132,10 @@ export class PDFGenerator {
 
   renderSelectedImage() {
     const { doc } = this;
-    const photo = $('#selected-image').attr('src');
-    const encodedPhotoURL = encodeURIComponent(photo);
-    doc.addImage(encodedPhotoURL, 'JPEG', 46, 12, 65, 65);
+    const imgEl = document.getElementById('selected-image');
+    if (imgEl) {
+      doc.addImage(imgEl, 'JPEG', 46, 12, 65, 65);
+    }
   }
 
   renderStyleText() {


### PR DESCRIPTION
## Summary
- ensure the selected image is passed directly to jsPDF
- stop the loader animation if items fail to load

## Testing
- `timeout 5 node test.js` *(fails: Output for session 'shell' contained a line exceeding the max of 1600 bytes)*